### PR TITLE
Fix ordering of reviews - return the highest scores first

### DIFF
--- a/api10.py
+++ b/api10.py
@@ -277,7 +277,7 @@ def fetch():
         items_new.append(item_new)
 
     # sort and cut to limit
-    sorted(items_new, key=lambda item: item['score'])
+    sorted(items_new, key=lambda item: item['score'], reverse=True)
     if item['limit'] > 0:
         items_new = items_new[:item['limit']]
 


### PR DESCRIPTION
Reverse the review order. In the current code it sorts them lowest to highest score. If you set a limit (e.g. "limit": 1) then you will get the worst review and not the best one. I think this hasn't been noticed because most apps have < 20 reviews in the language you can understand.

Note - I haven't actually tested this...